### PR TITLE
FASTK: Add Dockerfile and Makefile for convenience.

### DIFF
--- a/FASTK/Dockerfile
+++ b/FASTK/Dockerfile
@@ -1,0 +1,25 @@
+FROM docker.io/ubuntu:20.04
+
+ENV FASTK_COMMIT=f18a4e6d2207539f7b84461daebc54530a9559b0
+ENV FASTK_DEST_DIR=/usr/local/bin/
+
+# Install dependencies.
+RUN apt update
+RUN apt install -y \
+  gcc \
+  git \
+  libbz2-dev \
+  libcurl4-gnutls-dev \
+  liblzma-dev \
+  make \
+  zlib1g-dev
+# Build and install FASTK.
+WORKDIR /build/
+RUN git clone https://github.com/thegenemyers/FASTK.git
+WORKDIR /build/FASTK/
+RUN git checkout "${FASTK_COMMIT}"
+RUN make
+RUN make install DEST_DIR="${FASTK_DEST_DIR}"
+
+WORKDIR /data/
+CMD ["FastK"]

--- a/FASTK/Makefile
+++ b/FASTK/Makefile
@@ -1,0 +1,21 @@
+DOCKER ?= docker
+TAG = garg-fastk
+
+default : build
+.PHONY : default
+
+# Build container.
+build :
+	"$(DOCKER)" build --rm -t $(TAG) .
+
+# List up the commands.
+ls :
+	"$(DOCKER)" run --rm -t $(TAG) ls -1 /usr/local/bin
+
+# Run container.
+run :
+	"$(DOCKER)" run --rm -t $(TAG) $(CMD)
+
+# Clean all the container images.
+clean :
+	"$(DOCKER)" system prune -a -f


### PR DESCRIPTION
Initial files to create Docker images for FASTK.

Install `docker` or `podman` command on your environment. Then

```
$ cd FASTK
```

Build container

```
$ make
```

List up the built commands.

```
$ make ls
"docker" run --rm -t garg-fastk ls -1 /usr/local/bin
FastK
Fastcp
Fastmerge
Fastmv
Fastrm
Haplex
Histex
Homex
Logex
Profex
Symmex
Tabex
Vennex
```

Run the commands. I haven't tested the command options yet.

```
make run
```

```
make run CMD='FastK [options]'
```

```
make run CMD='Fastrm [options]'
```
