### PR TITLE
Use FastK Docker container.

### DIFF
--- a/FASTK/Makefile
+++ b/FASTK/Makefile
@@ -1,3 +1,6 @@
+# Note that Docker images with the schema version 2.1 built and pushed by Podman
+# cause an error when pulled by Docker. It's safe to use docker to build Docker
+# containers. See <https://discuss.dockstore.org/t/1972/12>.
 DOCKER ?= docker
 TAG = garg-fastk
 

--- a/bio-diversity-genomics-garg.wdl
+++ b/bio-diversity-genomics-garg.wdl
@@ -12,16 +12,13 @@ task FastK {
     File source
   }
   command {
-    echo "Running FastK.."
-    echo "soruce: ${source}"
-    # FastK -v -t -p "${source}"
-    cat /etc/os-release
+    echo "Running FastK with soruce: ${source} .."
+    FastK -v -t -p "${source}"
   }
   output {
     File result = stdout()
   }
   runtime {
-    docker: "docker.io/ubuntu:latest"
-    # docker: "quay.io/junaruga/garg-fastk:latest"
+    docker: "quay.io/junaruga/garg-fastk:latest"
   }
 }


### PR DESCRIPTION
In the current situation, I push the commit directly to this repository. However, as I want you to know this change, I would send the pull request.

---

Note that Docker images with the schema version 2.1 built and pushed by Podman cause an error when pulled by Docker. It's safe to use docker to build Docker containers. See <https://discuss.dockstore.org/t/1972/12>.

== How to run the Docker container ==

```
$ make run
```

Then check the `Cromwell.stdout.txt`, and find the temporary log directory, and find the `stderr` file.

E.g.

```
$ cat /tmp/1662557576842-0/cromwell-executions/BioDivGenomics/741c0347-eb22-4fff-893b-b7ce32329eeb/call-FastK/execution/stderr | head

Partitioning 1 .fastq file into 4 parts

Determining minimizer scheme & partition for hifi_input
  Estimate 2.906M 40-mers
```