### PR TITLE
Add GitHub Actions CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: build
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      # Setup Dockstore command line interface (CLI).
+      # https://dockstore.org/quick-start
+      # https://github.com/actions/setup-java
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - run: java --version
+      - run: env | grep '^PATH'
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+      - run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - run: ci/install-dockstore-cli.sh
+      - run: dockstore --version
+      # Check available memory size before running the workflow.
+      - run: free -h
+      - run: make lint
+      - run: make run

--- a/bio-diversity-genomics-garg.wdl
+++ b/bio-diversity-genomics-garg.wdl
@@ -13,7 +13,9 @@ task FastK {
   }
   command {
     echo "Running FastK with soruce: ${source} .."
-    FastK -v -t -p "${source}"
+    # Limit with the maximum memory 3 GB due to the GitHub Actions CI
+    # environment.
+    FastK -v -t -p -M3 "${source}"
   }
   output {
     File result = stdout()

--- a/ci/dot_dockstore_config
+++ b/ci/dot_dockstore_config
@@ -1,0 +1,2 @@
+# Caution: Don't set token in this file for a better security.
+server-url: https://dockstore.org/api

--- a/ci/install-dockstore-cli.sh
+++ b/ci/install-dockstore-cli.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+TOP_DIR="$(dirname "${0}")/.."
+# This directory is set in the GitHub Actions.
+BIN_DIR="$HOME/.local/bin"
+
+# Download the latest stable dockstore command.
+mkdir -p "${BIN_DIR}"
+curl -L -o "${BIN_DIR}/dockstore" \
+    https://github.com/dockstore/dockstore/releases/download/1.12.2/dockstore
+chmod +x "${BIN_DIR}/dockstore"
+ls -l "${BIN_DIR}/dockstore"
+command -v dockstore
+
+# Copy the config file. Note the config doesn't include the token for a better
+# security.
+mkdir -p ~/.dockstore
+cp -p ${TOP_DIR}/ci/dot_dockstore_config ~/.dockstore/config
+
+# Upgrade the dockstore to the 1.13.0-rc.0 or later versions
+# to use the `dockstore yaml` command.
+dockstore --upgrade-unstable
+
+dockstore --version


### PR DESCRIPTION
This pull request is to add the CI to this repository. Note we don't manage the dockstore access token for better security.