### PR TITLE
GENESCOPE.FK: Add Dockerfile and Makefile.

### DIFF
--- a/GENESCOPE.FK/.Rprofile
+++ b/GENESCOPE.FK/.Rprofile
@@ -1,0 +1,5 @@
+local({r <- getOption("repos")
+    # https://cran.r-project.org/mirrors.html
+    r["CRAN"] <- "https://cloud.r-project.org/"
+    options(repos=r)
+})

--- a/GENESCOPE.FK/Dockerfile
+++ b/GENESCOPE.FK/Dockerfile
@@ -1,0 +1,30 @@
+FROM docker.io/ubuntu:20.04
+
+ENV GENE_SCOPE_FK_COMMIT=380815c420f50171f9234a0fd1ff426b39829b91
+ENV GENE_SCOPE_FK_DEST_DIR=/usr/local/bin/
+
+# Install dependencies.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update
+RUN apt install -y \
+  git \
+  python3 \
+  r-base \
+  r-base-dev
+RUN R --version
+
+# Download the source.
+WORKDIR /build/
+RUN git clone https://github.com/thegenemyers/GENESCOPE.FK.git
+WORKDIR /build/GENESCOPE.FK/
+RUN git checkout "${GENE_SCOPE_FK_COMMIT}"
+
+# Install.
+COPY .Rprofile ~/
+COPY install_all.R .
+RUN Rscript install_all.R
+RUN Rscript -e "installed.packages()" | grep GeneScopeFK
+RUN cp -p GeneScopeFK.R "${GENE_SCOPE_FK_DEST_DIR}"
+
+WORKDIR /data/
+CMD ["GeneScopeFK.R"]

--- a/GENESCOPE.FK/Makefile
+++ b/GENESCOPE.FK/Makefile
@@ -1,0 +1,25 @@
+DOCKER ?= docker
+TAG = garg-gene-scope-fk
+
+default : build
+.PHONY : default
+
+# Build container.
+build :
+	"$(DOCKER)" build --rm -t $(TAG) .
+.PHONY : build
+
+# List up the commands.
+ls :
+	"$(DOCKER)" run --rm -t $(TAG) ls -1 /usr/local/bin
+.PHONY : ls
+
+# Run container.
+run :
+	"$(DOCKER)" run --rm -t $(TAG) $(CMD)
+.PHONY : run
+
+# Clean all the container images.
+clean :
+	"$(DOCKER)" system prune -a -f
+.PHONY : clean

--- a/GENESCOPE.FK/README.md
+++ b/GENESCOPE.FK/README.md
@@ -1,0 +1,15 @@
+# GENESCOPE.FK
+
+## How to build the Docker contaienr.
+
+```
+$ make
+```
+
+## How to push the Docker contaienr.
+
+```
+$ docker login quay.io
+$ docker tag garg-gene-scope-fk quay.io/junaruga/garg-gene-scope-fk
+$ docker push quay.io/junaruga/garg-gene-scope-fk:latest
+```

--- a/GENESCOPE.FK/install_all.R
+++ b/GENESCOPE.FK/install_all.R
@@ -1,0 +1,3 @@
+install.packages("argparse")
+install.packages("minpack.lm")
+install.packages('.', repos=NULL, type="source")


### PR DESCRIPTION
It is available at <https://quay.io/repository/junaruga/garg-gene-scope-fk>.

Run like ths.

```
$ docker run --rm -t quay.io/junaruga/garg-gene-scope-fk GeneScopeFK.R --version
GenomeScope 2.0
```

