### PR TITLE
Reduce the CI jobs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          - { targets: "test-containers" }
-          - { targets: "run-estimation" }
-          - { targets: "run-assembly" }
-          - { targets: "run-scaffold run-scaffold-is-test-0" }
-          - { targets: "run" }
+          - { targets: "run-estimation run-assembly run-scaffold run-scaffold-is-test-0" }
+          - { targets: "test-containers run" }
     steps:
       - uses: actions/checkout@v3
       # Setup Dockstore command line interface (CLI).


### PR DESCRIPTION
The 5 parallel jobs made the downloading error for the 5 processes to access the downloading site at the same timing.
See <https://github.com/GargGroup/BioDivGenomics/actions/runs/3040953813>.