### PR TITLE
Use pytest-3 or pytest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 WDL_FILE = bio-diversity-genomics-garg.wdl
 INPUT_FILE = bio-diversity-genomics-garg.inputs.json
 TEST_FILE = test/test.py
+PYTEST = $(shell script/find-pytest.sh)
 JOBS = $(shell expr `nproc --all` + 1)
 DOCKER ?= docker
 HIFIASM_TAG = quay.io/biocontainers/hifiasm:0.16.1--h5b5514e_1
@@ -39,7 +40,7 @@ run :
 # (e.g. "test_estimation")
 # $ make test TEST_FILE="test/test.py::test_estimation"
 test :
-	pytest-3 -v -n $(JOBS) $(TEST_OPTS) $(TEST_FILE)
+	$(PYTEST) -v -n $(JOBS) $(TEST_OPTS) $(TEST_FILE)
 .PHONY : test
 
 # Test remote Docker containers used in our workflows.

--- a/script/find-pytest.sh
+++ b/script/find-pytest.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eu
+
+PYTEST=$(command -v pytest-3 || command -v pytest)
+echo "${PYTEST}"


### PR DESCRIPTION
In the case of `apt install python3-pytest`, the `pytest-3` is installed. In the case of `pip install --user pytest`, the `pytest` is installed. We consider both cases.